### PR TITLE
Migrate simple requirements.txt to pyproject.toml.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Presented at 39C3 Hamburg: *["Pwn2Roll: Who Needs a 595€ Remote When You Have 
 # Setup (Ubuntu/Debian)
 sudo apt install python3.12-venv python3-bluez
 python3 -m venv .venv --system-site-packages
-.venv/bin/pip install -r requirements.txt
+.venv/bin/pip install -e .
 source .venv/bin/activate
 
 # Get your AES keys (scan the QR codes on your wheel hubs)

--- a/doc/usage-setup.md
+++ b/doc/usage-setup.md
@@ -20,7 +20,7 @@ which rfcomm hcitool bluetoothctl
 python3 -m venv .venv --system-site-packages
 
 # Install the rest
-.venv/bin/pip install -r requirements.txt
+.venv/bin/pip install -e .
 
 # Activate
 source .venv/bin/activate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "m5squared"
+version = "0.1.0"
+description = "M25 wheelchair drive toolkit"
+readme = "README.md"
+requires-python = ">=3.8"
+license = "AGPL-3.0-or-later"
+dependencies = [
+    "pycryptodome>=3.15.0",
+]
+
+[project.urls]
+Repository = "https://github.com/roll2own/m5squared"
+Documentation = "https://github.com/roll2own/m5squared/tree/main/doc"
+
+[project.scripts]
+m25-ecs = "m25_ecs:main"
+m25-qr-to-key = "m25_qr_to_key:main"
+m25-decrypt = "m25_decrypt:main"
+m25-encrypt = "m25_encrypt:main"
+m25-analyzer = "m25_analyzer:main"
+m25-bluetooth = "m25_bluetooth:main"
+m25-parking = "m25_parking:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-# wheelchair.py - M25 Protocol Toolkit
-# Required dependencies
-
-pycryptodome>=3.15.0
-
-# Optional: for Bluetooth scanning (m25_bluetooth.py scan)
-# Install via apt on Ubuntu/Debian: sudo apt install python3-bluez
-# pybluez is NOT pip-installable on most systems


### PR DESCRIPTION
We used a simple requirements.txt for developing the tools so far. Since we're professionals(tm) now, we should act like professionals(tm).